### PR TITLE
fix readme at deleteImage action, set response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ public function actions()
                     // You can customize response by this function, e.g. change response:
                     if (Yii::$app->request->isAjax) {
                         Yii::$app->response->getHeaders()->set('Vary', 'Accept');
-                        Yii::$app->response = Response::FORMAT_JSON;
+                        Yii::$app->response->format = yii\web\Response::FORMAT_JSON;
 
                         return ['status' => 'success', 'message' => 'Image deleted'];
                     } else {


### PR DESCRIPTION
An exception was occurring at the ajax call. This is why the image would't disappear after confirming deletion.